### PR TITLE
Mappings

### DIFF
--- a/src/crucible/core.clj
+++ b/src/crucible/core.clj
@@ -96,6 +96,12 @@
   [index values]
   (v/select index values))
 
+(defn find-in-map
+  "Returns the value corresponding to keys in a two-level map that is declared
+   in the Mappings section"
+  [map-name top-level-key second-level-key]
+  (v/find-in-map map-name top-level-key second-level-key))
+
 (defn import-value
   "Import an exported value"
   [value-name]

--- a/src/crucible/core.clj
+++ b/src/crucible/core.clj
@@ -11,6 +11,7 @@
 (s/def ::description string?)
 
 (s/def ::element (s/cat :type #{:parameter
+                                :mapping
                                 :resource
                                 :output}
                         :specification any?))
@@ -55,6 +56,11 @@
       :or {type ::p/string}
       :as options}]
   [:parameter (assoc options ::p/type type)])
+
+(defn mapping
+  "Make a template mapping element"
+  [& {:as keymaps}]
+  [:mapping keymaps])
 
 (defn resource
   "Make a template resource element"

--- a/src/crucible/encoding.clj
+++ b/src/crucible/encoding.clj
@@ -46,6 +46,10 @@
        :else x))
    element))
 
+(defmethod rewrite-element-data :mapping
+  [[_ element]]
+  element)
+
 (defn- rewrite-element [[key {:keys [type specification]}]]
   [(->key key) [type (rewrite-element-data [type specification])]])
 

--- a/src/crucible/mappings.clj
+++ b/src/crucible/mappings.clj
@@ -1,0 +1,20 @@
+(ns crucible.mappings
+  (:require [clojure.spec :as s]))
+
+(s/def ::name
+  string?)
+
+(d/def ::value
+  string?)
+
+(s/def ::keymap
+  (s/map-of ::name
+            ::value))
+
+(s/def ::mapping
+  (s/map-of string?
+            ::keymap))
+
+(s/def ::mappings
+  (s/map-of string?
+            ::mapping))

--- a/src/crucible/mappings.clj
+++ b/src/crucible/mappings.clj
@@ -1,20 +1,8 @@
 (ns crucible.mappings
   (:require [clojure.spec :as s]))
 
-(s/def ::name
-  string?)
-
-(d/def ::value
-  string?)
-
-(s/def ::keymap
-  (s/map-of ::name
-            ::value))
-
 (s/def ::mapping
   (s/map-of string?
-            ::keymap))
-
-(s/def ::mappings
-  (s/map-of string?
-            ::mapping))
+            (s/map-of
+             string?
+             string?)))

--- a/src/crucible/values.clj
+++ b/src/crucible/values.clj
@@ -44,11 +44,11 @@
 
 (defmethod value-type ::select [_] ::select)
 
-(s/def ::map-name ::fn-value)
+(s/def ::map-name (spec-or-ref keyword?))
 
-(s/def ::top-level-key ::fn-value)
+(s/def ::top-level-key (spec-or-ref string?))
 
-(s/def ::second-level-key ::fn-value)
+(s/def ::second-level-key (spec-or-ref string?))
 
 (s/def ::find-in-map (s/keys :req [::type
                                    ::map-name
@@ -83,7 +83,7 @@
 (defmethod encode-value ::find-in-map [{:keys [::map-name
                                                ::top-level-key
                                                ::second-level-key]}]
-  {"Fn::FindInMap" [(str map-name) (str top-level-key) (str second-level-key)]})
+  {"Fn::FindInMap" [(keys/->key map-name) (encode-value top-level-key) (encode-value second-level-key)]})
 
 (defn xref
   ([xref]

--- a/src/crucible/values.clj
+++ b/src/crucible/values.clj
@@ -108,6 +108,7 @@
 
 (defn find-in-map [map-name top-level-key second-level-key]
   {::type ::find-in-map
+   ::map-name map-name
    ::top-level-key top-level-key
    ::second-level-key second-level-key})
 

--- a/src/crucible/values.clj
+++ b/src/crucible/values.clj
@@ -83,7 +83,10 @@
 (defmethod encode-value ::find-in-map [{:keys [::map-name
                                                ::top-level-key
                                                ::second-level-key]}]
-  {"Fn::FindInMap" [(keys/->key map-name) (encode-value top-level-key) (encode-value second-level-key)]})
+  {"Fn::FindInMap"
+   [(keys/->key map-name)
+    (encode-value top-level-key)
+    (encode-value second-level-key)]})
 
 (defn xref
   ([xref]

--- a/src/crucible/values.clj
+++ b/src/crucible/values.clj
@@ -44,6 +44,18 @@
 
 (defmethod value-type ::select [_] ::select)
 
+(s/def ::map-name ::fn-value)
+
+(s/def ::top-level-key ::fn-value)
+
+(s/def ::second-level-key ::fn-value)
+
+(s/def ::find-in-map (s/keys :req [::type
+                                   ::map-name
+                                   ::top-level-key
+                                   ::second-level-key]))
+
+(defmethod value-type ::find-in-map [_] ::find-in-map)
 
 
 
@@ -68,6 +80,11 @@
 (defmethod encode-value ::select [{:keys [::index ::fn-values]}]
   {"Fn::Select" [(str index) (vec (map encode-value fn-values))]})
 
+(defmethod encode-value ::find-in-map [{:keys [::map-name
+                                               ::top-level-key
+                                               ::second-level-key]}]
+  {"Fn::FindInMap" [(str map-name) (str top-level-key) (str second-level-key)]})
+
 (defn xref
   ([xref]
    {::type ::xref ::ref xref})
@@ -88,6 +105,11 @@
   {::type ::select
    ::index index
    ::fn-values values})
+
+(defn find-in-map [map-name top-level-key second-level-key]
+  {::type ::find-in-map
+   ::top-level-key top-level-key
+   ::second-level-key second-level-key})
 
 (s/def ::value-name (spec-or-ref string?))
 (s/def ::import-value (s/keys :req [::value-name]))

--- a/test/crucible/encoding/template_test.clj
+++ b/test/crucible/encoding/template_test.clj
@@ -71,11 +71,13 @@
   (testing "template with single mapping"
     (is (= {"AWSTemplateFormatVersion" "2010-09-09",
             "Description" "t",
-            "Mappings" {"MyMap" {"foo" {"bar" "baz"}}}}
+            "Mappings" {"MyMap" {"foo" {"bar" "baz"}
+                                 "fee" {"fi" "fo"}}}}
            (cheshire.core/decode
             (encode
              (template "t"
-                       :my-map (mapping "foo" {"bar" "baz"})))))))
+                       :my-map (mapping "foo" {"bar" "baz"}
+                                        "fee" {"fi" "fo"})))))))
   (testing "template with multiple mappings"
     (is (= {"AWSTemplateFormatVersion" "2010-09-09",
             "Description" "t",

--- a/test/crucible/encoding/template_test.clj
+++ b/test/crucible/encoding/template_test.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :refer :all]
             [crucible
              [encoding :refer [encode]]
-             [core :refer [template parameter output xref join notification-arns]]
+             [core :refer [template parameter output xref join notification-arns mapping]]
              [policies :as pol]
              [parameters :as param]]
             [crucible.aws
@@ -66,6 +66,26 @@
              (template "t"
                        :my-param (parameter)
                        :my-other-param (parameter ::param/type ::param/number))))))))
+
+(deftest template-mappings-test
+  (testing "template with single mapping"
+    (is (= {"AWSTemplateFormatVersion" "2010-09-09",
+            "Description" "t",
+            "Mappings" {"MyMap" {"foo" {"bar" "baz"}}}}
+           (cheshire.core/decode
+            (encode
+             (template "t"
+                       :my-map (mapping "foo" {"bar" "baz"})))))))
+  (testing "template with multiple mappings"
+    (is (= {"AWSTemplateFormatVersion" "2010-09-09",
+            "Description" "t",
+            "Mappings" {"MyMap" {"foo" {"bar" "baz"}}
+                        "MyOtherMap" {"fee" {"fi" "fo"}}}}
+           (cheshire.core/decode
+            (encode
+             (template "t"
+                       :my-map (mapping "foo" {"bar" "baz"})
+                       :my-other-map (mapping "fee" {"fi" "fo"}))))))))
 
 (deftest template-resources-and-parameters-test
   (testing "template with parameter and resource"

--- a/test/crucible/mappings_test.clj
+++ b/test/crucible/mappings_test.clj
@@ -3,7 +3,7 @@
             [crucible.encoding :as enc]
             [clojure.test :refer :all]))
 
-(deftest mappings-test
+(deftest mapping-rewrite-test
   (testing "Rewrite is a no-op"
     (is (= {"foo" {"bar" "baz"
                    "quxx" "fizz"}}

--- a/test/crucible/mappings_test.clj
+++ b/test/crucible/mappings_test.clj
@@ -1,0 +1,11 @@
+(ns crucible.mappings-test
+  (:require [crucible.core :refer [mapping]]
+            [crucible.encoding :as enc]
+            [clojure.test :refer :all]))
+
+(deftest mappings-test
+  (testing "Rewrite is a no-op"
+    (is (= {"foo" {"bar" "baz"
+                   "quxx" "fizz"}}
+           (enc/rewrite-element-data (mapping "foo" {"bar" "baz"
+                                                     "quxx" "fizz"}))))))

--- a/test/crucible/resources_test.clj
+++ b/test/crucible/resources_test.clj
@@ -9,7 +9,8 @@
     (is (s/valid? ::res/resource-property-value (v/xref :foo))))
 
   (testing "function is valid"
-    (is (s/valid? ::res/resource-property-value (v/join "-" ["foo"])))))
+    (is (s/valid? ::res/resource-property-value (v/join "-" ["foo"])))
+    (is (s/valid? ::res/resource-property-value (v/find-in-map :foo-map "bar" "baz")))))
 
 (deftest resource-factory
   (testing "exception thrown if type does not look like a valid AWS resource type"

--- a/test/crucible/template_test.clj
+++ b/test/crucible/template_test.clj
@@ -163,17 +163,11 @@
            :vpc
            {:type :resource,
             :specification
-            #:crucible.resources{:type "AWS::EC2::VPC",
-                                 :properties
-                                 #:crucible.aws.ec2{:cidr-block
-                                                    #:crucible.values{:type
-                                                                      :crucible.values/find-in-map,
-                                                                      :map-name
-                                                                      :cidr-map,
-                                                                      :top-level-key
-                                                                      "bar",
-                                                                      :second-level-key
-                                                                      "baz"}}}}}}
+            {::res/type "AWS::EC2::VPC"
+             ::res/properties {::ec2/cidr-block {::v/type ::v/find-in-map
+                                                 ::v/map-name :cidr-map
+                                                 ::v/top-level-key "bar"
+                                                 ::v/second-level-key "baz"}}}}}}
          (template "t"
                    :cidr-map (mapping "bar" {"baz" "10.0.0.0/24"})
                    :vpc (ec2/vpc {::ec2/cidr-block (find-in-map :cidr-map "bar" "baz")})))))

--- a/test/crucible/template_test.clj
+++ b/test/crucible/template_test.clj
@@ -1,6 +1,7 @@
 (ns crucible.template-test
   (:require [clojure.test :refer :all]
-            [crucible.core :refer [template parameter resource output xref encode sub join mapping find-in-map]]
+            [crucible.core :refer [template parameter resource output xref
+                                   encode sub join mapping find-in-map]]
             [crucible.parameters :as param]
             [crucible.outputs :as out]
             [crucible.values :as v]

--- a/test/crucible/values_test.clj
+++ b/test/crucible/values_test.clj
@@ -22,8 +22,10 @@
 
 (deftest find-in-map-test
   (testing "all literals" (is (s/valid? ::v/value (cru/find-in-map :foo "bar" "baz"))))
-  (testing "both refs"    (is (s/valid? ::v/value (cru/find-in-map :foo (cru/xref :bar) (cru/xref :baz)))))
-  (testing "mixed"        (is (s/valid? ::v/value (cru/find-in-map :foo "bar" (cru/xref :baz))))))
+  (testing "both refs" (is (s/valid? ::v/value (cru/find-in-map :foo
+                                                                (cru/xref :bar)
+                                                                (cru/xref :baz)))))
+  (testing "mixed" (is (s/valid? ::v/value (cru/find-in-map :foo "bar" (cru/xref :baz))))))
 
 (deftest import-test
   (testing "import name" (is (s/valid? ::v/value (cru/import-value "foo")))))

--- a/test/crucible/values_test.clj
+++ b/test/crucible/values_test.clj
@@ -20,6 +20,11 @@
 
   (testing "1-index" (is (s/valid? ::v/value (cru/select 1 ["foo" (cru/xref :foo)])))))
 
+(deftest find-in-map-test
+  (testing "all literals" (is (s/valid? ::v/value (cru/find-in-map :foo "bar" "baz"))))
+  (testing "both refs"    (is (s/valid? ::v/value (cru/find-in-map :foo (cru/xref :bar) (cru/xref :baz)))))
+  (testing "mixed"        (is (s/valid? ::v/value (cru/find-in-map :foo "bar" (cru/xref :baz))))))
+
 (deftest import-test
   (testing "import name" (is (s/valid? ::v/value (cru/import-value "foo")))))
 


### PR DESCRIPTION
This pull adds support for [mappings](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/mappings-section-structure.html) and the associated `Fn::FindInMap` intrinsic function.

Mappings can be defined like so:
```clojure
(template "t"
                 :my-map (mapping "foo" {"bar" "baz"}
                                  "hey" {"what" "now"})
                 :my-other-map (mapping "fee" {"fi" "fo"}))
```

And with `crucible.core/find-in-map` you can use the intrinsic function in a leaf:
```clojure
(find-in-map :my-map "foo" "bar")
```

I think I've followed the conventions on value polymorphism, etc., and there's testing at a couple of levels. Thanks again for this cool library, already got some great use out of it!