### PR TITLE
iam action hyphens in api gw actions

### DIFF
--- a/src/crucible/aws/iam.clj
+++ b/src/crucible/aws/iam.clj
@@ -36,7 +36,7 @@
 (s/def ::not-principal ::principal)
 
 (s/def ::action-element (spec-or-ref (s/and string?
-                                            #(re-matches #"[a-zA-Z0-9*:]+" %))))
+                                            #(re-matches #"[a-zA-Z0-9*:_\-]+" %))))
 
 (s/def ::action (s/or :single ::action-element
                       :list (s/+ ::action-element)))

--- a/test/crucible/aws/iam_test.clj
+++ b/test/crucible/aws/iam_test.clj
@@ -36,6 +36,8 @@
 
 (deftest action-tests
 
+  (testing "hyphen in action" (is (valid ::iam/action "execute-api:Invoke")))
+
   (testing "all actions" (is (valid ::iam/action "*")))
 
   (testing "single action" (is (valid ::iam/action "s3:PutObject")))


### PR DESCRIPTION
API Gateway has hyphens in its `execute-api` actions, eg. http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-iam-policy-examples-for-api-execution.html