### PR TITLE
Require SubnetIds in AWS::Lambda::Function.VpcConfig

### DIFF
--- a/src/crucible/aws/lambda.clj
+++ b/src/crucible/aws/lambda.clj
@@ -6,8 +6,7 @@
 
 (s/def ::security-group-ids (s/* (spec-or-ref string?)))
 
-(s/def ::vpc-config (s/keys :req [::security-group-ids]
-                            :opt [::subnet-ids]))
+(s/def ::vpc-config (s/keys :req [::security-group-ids ::subnet-ids]))
 
 (s/def ::timeout (spec-or-ref (s/and pos-int? #(<= % (* 5 60)))))
 


### PR DESCRIPTION
This was the very first spec I checked while investigating the feasibility of issue #93.

Documentation: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-vpcconfig.html