### PR TITLE
bumps jackson to fix vuln

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[camel-snake-kebab "0.4.0"]
-                 [cheshire "5.7.1"]
+                 [cheshire "5.8.0"]
                  [org.clojure/tools.namespace "0.2.11"]
                  [org.clojure/tools.cli "0.3.5"]]
   :dependency-check {:throw true}


### PR DESCRIPTION
When https://nvd.nist.gov/vuln/detail/CVE-2016-7051 updates, dep check should pass.