### PR TITLE
Improve the readability of spec errors

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,8 @@
   :dependencies [[camel-snake-kebab "0.4.0"]
                  [cheshire "5.8.0"]
                  [org.clojure/tools.namespace "0.2.11"]
-                 [org.clojure/tools.cli "0.3.5"]]
+                 [org.clojure/tools.cli "0.3.5"]
+                 [expound "0.3.4"]]
   :dependency-check {:throw true}
   :exclusions [org.clojure/clojure]
   :codox {:output-path "target/docs"

--- a/src/crucible/core.clj
+++ b/src/crucible/core.clj
@@ -6,7 +6,8 @@
             [crucible.parameters :as p]
             [crucible.resources :as r]
             [crucible.outputs :as o]
-            [crucible.encoding :as encoding]))
+            [crucible.encoding :as encoding]
+            [expound.alpha :as expound]))
 
 (s/def ::description string?)
 
@@ -43,7 +44,8 @@
          spec ::template
          parsed (s/conform spec input)]
      (if (= parsed ::s/invalid)
-       (throw (ex-info "Invalid input" (s/explain-data spec input)))
+       (throw (AssertionError. (str "Invalid input"
+                                    (expound/expound-str spec input))))
        (-> parsed
            validate
            (with-meta {::template true})))))

--- a/src/crucible/core.clj
+++ b/src/crucible/core.clj
@@ -44,8 +44,8 @@
          spec ::template
          parsed (s/conform spec input)]
      (if (= parsed ::s/invalid)
-       (throw (AssertionError. (str "Invalid input"
-                                    (expound/expound-str spec input))))
+       (throw (ex-info (str "Invalid input" (expound/expound-str spec input))
+                       (s/explain-data spec input)))
        (-> parsed
            validate
            (with-meta {::template true})))))

--- a/src/crucible/resources.clj
+++ b/src/crucible/resources.clj
@@ -1,6 +1,7 @@
 (ns crucible.resources
   (:require [clojure.spec.alpha :as s]
-            [crucible.policies :as policies]))
+            [crucible.policies :as policies]
+            [expound.alpha :as expound]))
 
 (s/def ::props-type keyword?)
 
@@ -34,12 +35,13 @@
 
 (defn resource-factory [resource-type props-spec]
   (if-not (s/valid? ::type resource-type)
-    (throw (ex-info "Invalid resource name" (s/explain-data ::type resource-type)))
+    (throw (AssertionError. (str "Invalid resource name"
+                                 (expound/expound-str ::type resource-type))))
     (fn [& [props & policies]]
       [:resource
        (cond
-         (invalid? props-spec props) (throw (ex-info "Invalid resource properties"
-                                                     (s/explain-data props-spec props)))
+         (invalid? props-spec props) (throw (AssertionError. (str "Invalid resource properties"
+                                                                  (expound/expound-str props-spec props))))
 
          :else (-> {::type resource-type
                     ::properties props}

--- a/src/crucible/resources.clj
+++ b/src/crucible/resources.clj
@@ -35,14 +35,13 @@
 
 (defn resource-factory [resource-type props-spec]
   (if-not (s/valid? ::type resource-type)
-    (throw (AssertionError. (str "Invalid resource name"
-                                 (expound/expound-str ::type resource-type))))
+    (throw (ex-info (str "Invalid resource name" (expound/expound-str ::type resource-type))
+                    (s/explain-data ::type resource-type)))
     (fn [& [props & policies]]
       [:resource
        (cond
-         (invalid? props-spec props) (throw (AssertionError. (str "Invalid resource properties"
-                                                                  (expound/expound-str props-spec props))))
-
+         (invalid? props-spec props) (throw (ex-info (str "Invalid resource properties" (expound/expound-str props-spec props))
+                                                     (s/explain-data props-spec props)))
          :else (-> {::type resource-type
                     ::properties props}
                    (merge (into {} (s/conform ::policy-list policies)))))])))

--- a/src/crucible/resources.clj
+++ b/src/crucible/resources.clj
@@ -40,8 +40,9 @@
     (fn [& [props & policies]]
       [:resource
        (cond
-         (invalid? props-spec props) (throw (ex-info (str "Invalid resource properties" (expound/expound-str props-spec props))
-                                                     (s/explain-data props-spec props)))
+         (invalid? props-spec props)
+         (throw (ex-info (str "Invalid resource properties" (expound/expound-str props-spec props))
+                         (s/explain-data props-spec props)))
          :else (-> {::type resource-type
                     ::properties props}
                    (merge (into {} (s/conform ::policy-list policies)))))])))


### PR DESCRIPTION
This improves the readability of spec errors. This is not really important functionality, so feel free to discard as a matter of preference. Worth checking out though!

I could also add back ex-info and do both expound and the original spec error. Let me know what you think.