### PR TITLE
Add AWS::IAM::Role

### DIFF
--- a/src/crucible/aws/iam.clj
+++ b/src/crucible/aws/iam.clj
@@ -83,8 +83,8 @@
 
 (s/def ::policies (s/* ::policy))
 
-(s/def ::role (s/keys :req [::assume-role-policy-document
-                            ::path
+(s/def ::role (s/keys :req [::assume-role-policy-document]
+                      :opt [::path
                             ::policies]))
 
 (s/def ::password string?)
@@ -106,6 +106,8 @@
                             ::username]))
 
 (defresource policy "AWS::IAM::Policy" ::policy)
+
+(defresource role "AWS::IAM::Role" ::role)
 
 (defresource user "AWS::IAM::User" ::user)
 

--- a/test/crucible/aws/iam_test.clj
+++ b/test/crucible/aws/iam_test.clj
@@ -60,10 +60,11 @@
 
   (testing "simple role"
     (is (valid ::iam/role
-               {::iam/assume-role-policy-document {::iam/version "2012-10-17"
-                                                   ::iam/statement [{::iam/effect "Allow"
-                                                                     ::iam/principal {::iam/service ["ecs-tasks.amazonaws.com"]}
-                                                                     ::iam/action ["sts:AssumeRole"]}]}}))))
+               {::iam/assume-role-policy-document
+                {::iam/version "2012-10-17"
+                 ::iam/statement [{::iam/effect "Allow"
+                                   ::iam/principal {::iam/service ["ecs-tasks.amazonaws.com"]}
+                                   ::iam/action ["sts:AssumeRole"]}]}}))))
 
 (deftest condition-tests
 

--- a/test/crucible/aws/iam_test.clj
+++ b/test/crucible/aws/iam_test.clj
@@ -56,6 +56,12 @@
 
   (testing "not resource" (is (valid ::iam/not-resource "foo"))))
 
+(deftest role-tests
+
+  (testing "simple role" (is (valid ::iam/role {::iam/assume-role-policy-document {::iam/version "2012-10-17"
+                                                                                   ::iam/statement [{::iam/effect "Allow"
+                                                                                                     ::iam/principal {::iam/service ["ecs-tasks.amazonaws.com"]}
+                                                                                                     ::iam/action ["sts:AssumeRole"]}]}})))
 (deftest condition-tests
 
   (testing "single condition"

--- a/test/crucible/aws/iam_test.clj
+++ b/test/crucible/aws/iam_test.clj
@@ -58,10 +58,13 @@
 
 (deftest role-tests
 
-  (testing "simple role" (is (valid ::iam/role {::iam/assume-role-policy-document {::iam/version "2012-10-17"
-                                                                                   ::iam/statement [{::iam/effect "Allow"
-                                                                                                     ::iam/principal {::iam/service ["ecs-tasks.amazonaws.com"]}
-                                                                                                     ::iam/action ["sts:AssumeRole"]}]}})))
+  (testing "simple role"
+    (is (valid ::iam/role
+               {::iam/assume-role-policy-document {::iam/version "2012-10-17"
+                                                   ::iam/statement [{::iam/effect "Allow"
+                                                                     ::iam/principal {::iam/service ["ecs-tasks.amazonaws.com"]}
+                                                                     ::iam/action ["sts:AssumeRole"]}]}}))))
+
 (deftest condition-tests
 
   (testing "single condition"


### PR DESCRIPTION
For this existing resources, I did not split the resources into different namespaces, like @taffowl did with the ecs namespace. Although I think it is a good idea to be consistent, I suggest changing the existing resources / namespaces in one pull request.