### PR TITLE
Add a deps.edn to ease local development

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,6 @@
+{:paths ["src"]
+ :deps {camel-snake-kebab {:mvn/version "0.4.0"}
+        cheshire {:mvn/version "5.8.0"}
+        org.clojure/tools.namespace {:mvn/version "0.2.11"}
+        org.clojure/tools.cli {:mvn/version "0.3.7"}
+        expound {:mvn/version "0.6.0"}}}


### PR DESCRIPTION
Projects that use tools-deps and want to depend on a specific commit sha
in the crucible project need a deps.edn present.
Ideally project.clj and deps.end dependencies should sync automatically.
The is some activity in that area, for example
https://github.com/RickMoynihan/lein-tools-deps could fix this. For now
we will have to keep it in sync. Switching to tools-deps is also an
option...