### PR TITLE
Fix typo in spec

### DIFF
--- a/src/crucible/aws/kinesis.clj
+++ b/src/crucible/aws/kinesis.clj
@@ -9,6 +9,6 @@
 
 (s/def ::stream (s/keys :req [::shard-count]
                         :opt [::name
-                              :crucible.resourcs/tags]))
+                              :crucible.resources/tags]))
 
 (defresource stream "AWS::Kinesis::Stream" ::stream)


### PR DESCRIPTION
`:crucible.resourcs/tags` -> `:crucible.resources/tags`