### PR TITLE
Add some missing attributes in kinesis and lambda

### DIFF
--- a/src/crucible/aws/kinesis.clj
+++ b/src/crucible/aws/kinesis.clj
@@ -4,11 +4,13 @@
             [crucible.resources :refer [spec-or-ref defresource]]))
 
 (s/def ::shard-count (spec-or-ref pos-int?))
+(s/def ::retention-period-hours (spec-or-ref pos-int?))
 
 (s/def ::name (spec-or-ref string?))
 
 (s/def ::stream (s/keys :req [::shard-count]
                         :opt [::name
+                              ::retention-period-hours
                               :crucible.resources/tags]))
 
 (defresource stream "AWS::Kinesis::Stream" ::stream)

--- a/src/crucible/aws/lambda.clj
+++ b/src/crucible/aws/lambda.clj
@@ -54,7 +54,8 @@
                                 ::runtime
                                 ::vpc-config
                                 ::environment
-                                ::reserved-concurrent-executions]))
+                                ::reserved-concurrent-executions
+                                ::timeout]))
 
 (defresource function "AWS::Lambda::Function" ::function)
 


### PR DESCRIPTION
`::kinesis/retention-period-hours` was missing. `::lambda/timeout` existed already as a spec, but it didn't make it into the `::lambda/function` spec