### PR TITLE
Support for AWS SAM templates

### DIFF
--- a/src/crucible/aws/.#elbv2.clj
+++ b/src/crucible/aws/.#elbv2.clj
@@ -1,1 +1,0 @@
-gerstree@gerstree.15907:1540559958

--- a/src/crucible/aws/dynamodb.clj
+++ b/src/crucible/aws/dynamodb.clj
@@ -1,6 +1,7 @@
 (ns crucible.aws.dynamodb
   "Resources in AWS::DynamoDB::*"
-  (:require [crucible.resources :refer [spec-or-ref defresource]]
+  (:require [crucible.encoding.keys :refer [->key]]
+            [crucible.resources :refer [spec-or-ref defresource]]
             [clojure.spec.alpha :as s]))
 
 (s/def ::table-name (spec-or-ref string?))
@@ -34,7 +35,8 @@
 (s/def ::projection (s/keys :opt [::non-key-attributes
                                   ::projection-type]))
 
-(s/def ::capacity-units (spec-or-ref string?))
+(s/def ::capacity-units (spec-or-ref (s/or :string string?
+                                           :integer int?)))
 
 (s/def ::read-capacity-units ::capacity-units)
 
@@ -63,12 +65,22 @@
 
 (s/def ::stream-specification (s/keys :req [::stream-view-type]))
 
+(s/def ::sse-enabled (spec-or-ref boolean?))
+
+(defmethod ->key ::sse-enabled [_] "SSEEnabled")
+
+(s/def ::sse-specification
+  (s/keys :req [::sse-enabled]))
+
+(defmethod ->key ::sse-specification [_] "SSESpecification")
+
 (s/def ::table (s/keys :req [::attribute-definitions
                              ::key-schema
                              ::provisioned-throughput]
                        :opt [::table-name
                              ::stream-specification
                              ::global-secondary-indexes
-                             ::local-secondary-indexes]))
+                             ::local-secondary-indexes
+                             ::sse-specification]))
 
 (defresource table "AWS::DynamoDB::Table" ::table)

--- a/src/crucible/aws/iam.clj
+++ b/src/crucible/aws/iam.clj
@@ -54,6 +54,8 @@
 (s/def ::condition (s/map-of (s/or :str string?
                                    :kwd keyword?) (s/map-of string? any?)))
 
+(s/def ::effect #{"Allow" "Deny"})
+
 (s/def ::statement (s/* (s/keys :opt [::effect
                                       ::principal
                                       ::not-principal

--- a/src/crucible/aws/serverless.clj
+++ b/src/crucible/aws/serverless.clj
@@ -1,0 +1,47 @@
+(ns crucible.aws.serverless
+  (:require [crucible.resources :refer [spec-or-ref]]
+            [clojure.spec.alpha :as s]))
+
+;; ARN
+(s/def ::arn (spec-or-ref string?))
+
+;; Variables
+(s/def ::variables (s/map-of (s/or :kw keyword? :str string?) (spec-or-ref string?)))
+
+;; Tags
+(s/def ::tags (s/map-of (s/or :kw keyword? :str string?) (spec-or-ref string?)))
+
+;; S3 Location
+(s/def ::bucket (spec-or-ref string?))
+
+(s/def ::key (spec-or-ref string?))
+
+(s/def ::version (spec-or-ref int?))
+
+(s/def ::s3-location
+  (s/keys :req [::bucket
+                ::key]
+          :opt [::version]))
+;; CORS
+(s/def ::allow-methods (spec-or-ref string?))
+
+(s/def ::allow-headers (spec-or-ref string?))
+
+(s/def ::allow-origin (spec-or-ref string?))
+
+(s/def ::max-age (spec-or-ref string?))
+
+(s/def ::cors
+  (s/keys :req [::allow-origin]
+          :opt [::allow-methods
+                ::allow-headers
+                ::max-age]))
+
+;; Primary Key
+(s/def ::name (spec-or-ref string?))
+
+(s/def ::type (spec-or-ref #{"String" "Number" "Binary"}))
+
+(s/def ::primary-key
+  (s/keys :opt [::name
+                ::type]))

--- a/src/crucible/aws/serverless/api.clj
+++ b/src/crucible/aws/serverless/api.clj
@@ -1,0 +1,51 @@
+(ns crucible.aws.serverless.api
+  (:require [crucible.aws.serverless :as sam]
+            [crucible.resources :refer [spec-or-ref defresource]]
+            [clojure.spec.alpha :as s]))
+
+(s/def ::name (spec-or-ref string?))
+
+(s/def ::stage-name (spec-or-ref string?))
+
+(s/def ::definition-uri (spec-or-ref (s/or :string string?
+                                           :s3-location ::sam/s3-location)))
+
+(s/def ::definition-body map?)
+
+(s/def ::cache-clustering-enabled (spec-or-ref boolean?))
+
+(s/def ::cache-cluster-size (spec-or-ref string?))
+
+(s/def ::variables ::sam/variables)
+
+(s/def ::http-method (spec-or-ref string?))
+
+(s/def ::resource-path (spec-or-ref string?))
+
+(s/def ::method-setting
+  (s/keys :req [::http-method
+                ::resource-path]))
+
+(s/def ::method-settings (s/* ::method-settings))
+
+(s/def ::endpoint-configuration #{"REGIONAL" "EDGE" "PRIVATE"})
+
+(s/def ::binary-media-types (s/* (spec-or-ref string?)))
+
+(s/def ::cors (spec-or-ref (s/or :domain string?
+                                 :cors-configuration ::sam/cors)))
+
+(s/def ::api
+  (s/keys :req [::stage-name]
+          :opt [::name
+                ::definition-uri
+                ::definition-body
+                ::cache-clustering-enabled
+                ::cache-cluster-size
+                ::variables
+                ::method-settings
+                ::endpoint-configuration
+                ::binary-media-types
+                ::cors]))
+
+(defresource api "AWS::Serverless::Api" ::api)

--- a/src/crucible/aws/serverless/function.clj
+++ b/src/crucible/aws/serverless/function.clj
@@ -1,0 +1,58 @@
+(ns crucible.aws.serverless.function
+  (:require [crucible.aws.iam :as iam]
+            [crucible.aws.lambda :as lambda]
+            [crucible.aws.serverless :as sam]
+            [crucible.aws.serverless.function.event-source :as event-source]
+            [crucible.resources :refer [spec-or-ref defresource]]
+            [clojure.spec.alpha :as s]))
+
+(s/def ::handler (spec-or-ref string?))
+
+(s/def ::runtime (spec-or-ref string?))
+
+(s/def ::code-uri
+  (spec-or-ref
+   (s/or :string string?
+         :s3-location ::sam/s3-location)))
+
+(s/def ::function-name (spec-or-ref string?))
+
+(s/def ::description (spec-or-ref string?))
+
+(s/def ::memory-size (spec-or-ref int?))
+
+(s/def ::timeout (spec-or-ref int?))
+
+(s/def ::role ::sam/arn)
+
+(s/def ::policies (s/or :name string?
+                        :policy ::iam/policy
+                        :list (s/* (s/or :name string?
+                                         :policy ::iam/policy-document))))
+
+(s/def ::events (spec-or-ref (s/map-of (s/or :string string? :keyword keyword?)
+                                       ::event-source/event-source)))
+
+(s/def ::vpc-config ::lambda/vpc-config)
+
+(s/def ::variables ::sam/variables)
+
+(s/def ::environment (s/keys :req [::variables]))
+
+(s/def ::tags ::sam/tags)
+
+(s/def ::function
+  (s/keys :req [::handler
+                ::runtime
+                ::code-uri]
+          :opt [::function-name
+                ::description
+                ::memory-size
+                ::timeout
+                ::role
+                ::policies
+                ::environment
+                ::vpc-config
+                ::tags]))
+
+(defresource function "AWS::Serverless::Function" ::function)

--- a/src/crucible/aws/serverless/function/event_source.clj
+++ b/src/crucible/aws/serverless/function/event_source.clj
@@ -1,0 +1,40 @@
+(ns crucible.aws.serverless.function.event-source
+  (:require [crucible.aws.serverless :as sam]
+            [crucible.aws.serverless.function.event-source.api :as api]
+            [crucible.aws.serverless.function.event-source.kinesis :as kinesis]
+            [crucible.aws.serverless.function.event-source.schedule :as schedule]
+            [crucible.aws.serverless.function.event-source.sns :as sns]
+            [crucible.aws.serverless.function.event-source.sqs :as sqs]
+            [crucible.resources :refer [spec-or-ref defresource]]
+            [clojure.spec.alpha :as s]))
+
+(s/def ::type
+  #{"S3" "SNS" "Kinesis" "DynamoDB" "Api" "Schedule" "CloudWatchEvent" "CloudWatchLogs"})
+
+(defmulti event-source ::type)
+
+(defmethod event-source "Kinesis" [_]
+  (s/keys :req [::type
+                ::kinesis/properties]))
+
+(defmethod event-source "Schedule" [_]
+  (s/keys :req [::type
+                ::schedule/properties]))
+
+(defmethod event-source "Api" [_]
+  (s/keys :req [::type
+                ::api/properties]))
+
+(defmethod event-source "SNS" [_]
+  (s/keys :req [::type
+                ::sns/properties]))
+
+(defmethod event-source "SQS" [_]
+  (s/keys :req [::type
+                ::sqs/properties]))
+
+(defmethod event-source :default [_]
+  (s/keys :req [::type]))
+
+(s/def ::event-source
+  (s/multi-spec event-source ::type))

--- a/src/crucible/aws/serverless/function/event_source/api.clj
+++ b/src/crucible/aws/serverless/function/event_source/api.clj
@@ -1,0 +1,13 @@
+(ns crucible.aws.serverless.function.event-source.api
+  (:require [crucible.resources :refer [spec-or-ref]]
+            [clojure.spec.alpha :as s]))
+
+(s/def ::path (spec-or-ref string?))
+
+(s/def ::method (spec-or-ref string?))
+
+(s/def ::rest-api-id (spec-or-ref string?))
+
+(s/def ::properties
+  (s/keys :req [::path
+                ::method]))

--- a/src/crucible/aws/serverless/function/event_source/kinesis.clj
+++ b/src/crucible/aws/serverless/function/event_source/kinesis.clj
@@ -1,0 +1,15 @@
+(ns crucible.aws.serverless.function.event-source.kinesis
+  (:require [crucible.aws.serverless :as sam]
+            [crucible.resources :refer [spec-or-ref]]
+            [clojure.spec.alpha :as s]))
+
+(s/def ::stream ::sam/arn)
+
+(s/def ::starting-position (spec-or-ref #{"TRIM_HORIZON" "LATEST"}))
+
+(s/def ::batch-size (spec-or-ref integer?))
+
+(s/def ::properties
+  (s/keys :req [::stream
+                ::starting-position]
+          :opt [::batch-size]))

--- a/src/crucible/aws/serverless/function/event_source/schedule.clj
+++ b/src/crucible/aws/serverless/function/event_source/schedule.clj
@@ -1,0 +1,8 @@
+(ns crucible.aws.serverless.function.event-source.schedule
+  (:require [crucible.resources :refer [spec-or-ref]]
+            [clojure.spec.alpha :as s]))
+
+(s/def ::schedule (spec-or-ref string?))
+
+(s/def ::properties
+  (s/keys :req [::schedule]))

--- a/src/crucible/aws/serverless/function/event_source/sns.clj
+++ b/src/crucible/aws/serverless/function/event_source/sns.clj
@@ -1,0 +1,9 @@
+(ns crucible.aws.serverless.function.event-source.sns
+  (:require [crucible.aws.serverless :as sam]
+            [crucible.resources :refer [spec-or-ref]]
+            [clojure.spec.alpha :as s]))
+
+(s/def ::topic ::sam/arn)
+
+(s/def ::properties
+  (s/keys :req [::topic]))

--- a/src/crucible/aws/serverless/function/event_source/sqs.clj
+++ b/src/crucible/aws/serverless/function/event_source/sqs.clj
@@ -1,0 +1,12 @@
+(ns crucible.aws.serverless.function.event-source.sqs
+  (:require [crucible.aws.serverless :as sam]
+            [crucible.resources :refer [spec-or-ref]]
+            [clojure.spec.alpha :as s]))
+
+(s/def ::queue ::sam/arn)
+
+(s/def ::batch-size (spec-or-ref integer?))
+
+(s/def ::properties
+  (s/keys :req [::queue]
+          :opt [::batch-size]))

--- a/src/crucible/aws/serverless/globals.clj
+++ b/src/crucible/aws/serverless/globals.clj
@@ -1,0 +1,38 @@
+(ns crucible.aws.serverless.globals
+  (:require [crucible.aws.serverless.api :as sam.api]
+            [crucible.aws.serverless.function :as sam.function]
+            [clojure.spec.alpha :as s]
+            [expound.alpha :as expound]))
+
+(s/def ::function (s/keys :opt [::sam.function/handler
+                                ::sam.function/runtime
+                                ::sam.function/code-uri
+                                ::sam.function/description
+                                ::sam.function/memory-size
+                                ::sam.function/timeout
+                                ::sam.function/vpc-config
+                                ::sam.function/environment
+                                ::sam.function/tags]))
+
+(s/def ::api (s/keys :opt [::sam.api/name
+                           ::sam.api/definition-uri
+                           ::sam.api/cache-clustering-enabled
+                           ::sam.api/cache-cluster-size
+                           ::sam.api/variables
+                           ::sam.api/endpoint-configuration
+                           ::sam.api/method-settings
+                           ::sam.api/binary-media-types
+                           ::sam.api/cors]))
+
+(s/def ::globals (s/keys :opt [::function
+                               ::api]))
+
+(defn globals
+  "Validates Serverless Application Model globals returning a vector of
+  :globals and the conformed data"
+  [props]
+  (if-not (s/valid? ::globals props)
+    (throw (ex-info (str "Invalid globals property"
+                         (expound/expound-str ::globals props))
+                    (s/explain-data ::globals props)))
+    [:globals props]))

--- a/src/crucible/aws/serverless/layer_version.clj
+++ b/src/crucible/aws/serverless/layer_version.clj
@@ -1,0 +1,27 @@
+(ns crucible.aws.serverless.layer-version
+  (:require [crucible.resources :refer [spec-or-ref defresource]]
+            [crucible.aws.serverless :as sam]
+            [clojure.spec.alpha :as s]))
+
+(s/def ::layer-name (spec-or-ref string?))
+
+(s/def ::description (spec-or-ref string?))
+
+(s/def ::content-uri (spec-or-ref (s/or :string string?
+                                        :s3-location ::sam/s3-location)))
+
+(s/def ::compatible-runtimes (spec-or-ref (s/* string?)))
+
+(s/def ::license-info (spec-or-ref string?))
+
+(s/def ::retention-policy (spec-or-ref #{"Retain" "Delete"}))
+
+(s/def ::layer-version
+  (s/keys :req [::content-uri]
+          :opt [::layer-name
+                ::description
+                ::compatible-runtimes
+                ::license-info
+                ::retention-policy]))
+
+(defresource layer-version "AWS::Serverless::LayerVersion" ::layer-version)

--- a/src/crucible/aws/serverless/simple_table.clj
+++ b/src/crucible/aws/serverless/simple_table.clj
@@ -1,0 +1,24 @@
+(ns crucible.aws.serverless.simple-table
+  (:require [crucible.aws.serverless :as sam]
+            [crucible.aws.dynamodb :as ddb]
+            [crucible.resources :refer [spec-or-ref defresource]]
+            [clojure.spec.alpha :as s]))
+
+(s/def ::primary-key (spec-or-ref ::sam/primary-key))
+
+(s/def ::provisioned-throughput ::ddb/provisioned-throughput)
+
+(s/def ::tags ::sam/tags)
+
+(s/def ::table-name (spec-or-ref string?))
+
+(s/def ::sse-specification ::ddb/sse-specification)
+
+(s/def ::simple-table
+  (s/keys :opt [::primary-key
+                ::provisioned-throughput
+                ::tags
+                ::table-name
+                ::sse-specification]))
+
+(defresource simple-table "AWS::Serverless::SimpleTable" ::simple-table)

--- a/src/crucible/encoding/serverless.clj
+++ b/src/crucible/encoding/serverless.clj
@@ -1,0 +1,27 @@
+(ns crucible.encoding.serverless
+  (:require [crucible.encoding.keys :refer [->key]]
+            [crucible.encoding :as encoding]
+            [cheshire.core :as json]))
+
+(defn build
+  "Create a Serverless Application Model compatible data structure ready for
+  JSON encoding from the template and any global template values"
+  ([template]
+   (build template nil))
+  ([template globals]
+   (-> template
+       :elements
+       (#'encoding/elements->template
+        (cond-> {(->key :aws-template-format-version) "2010-09-09"
+                 (->key :description) (or (:description template)
+                                          "No description provided")
+                 (->key :transform) "AWS::Serverless-2016-10-31"}
+          globals (assoc (->key :globals)
+                         (encoding/rewrite-element-data globals)))))))
+
+(defn encode
+  "Convert the template data structure into a JSON-encoded string"
+  ([template]
+   (encode template nil))
+  ([template globals]
+   (json/encode (build template globals))))

--- a/test/crucible/aws/serverless/api_test.clj
+++ b/test/crucible/aws/serverless/api_test.clj
@@ -1,0 +1,19 @@
+(ns crucible.aws.serverless.api-test
+  (:require [crucible.aws.serverless :as sam]
+            [crucible.aws.serverless.api :as api]
+            [crucible.core :refer [xref]]
+            [crucible.resources :as res]
+            [clojure.test :refer :all]
+            [crucible.encoding :as encoding]))
+
+(deftest api-test
+  (testing "encode"
+    (is (= {"Type" "AWS::Serverless::Api"
+            "Properties" {"Name" "my-api"
+                          "StageName" "LATEST"
+                          "Cors" {"AllowOrigin" "www.example.com"}}}
+           (encoding/rewrite-element-data
+            (api/api
+             {::api/name "my-api"
+              ::api/stage-name "LATEST"
+              ::api/cors {::sam/allow-origin "www.example.com"}}))))))

--- a/test/crucible/aws/serverless/function_test.clj
+++ b/test/crucible/aws/serverless/function_test.clj
@@ -1,0 +1,50 @@
+(ns crucible.aws.serverless.function-test
+  (:require [crucible.aws.serverless :as sam]
+            [crucible.aws.serverless.function :as f]
+            [crucible.aws.serverless.function.event-source :as es]
+            [crucible.aws.serverless.function.event-source.kinesis :as k]
+            [crucible.core :refer [xref]]
+            [crucible.resources :as res]
+            [clojure.test :refer :all]
+            [crucible.aws.iam :as iam]))
+
+(deftest function-test
+  (testing "encode"
+    (is (= {"Type" "AWS::Serverless::Function"
+            "Properties"
+            {"Handler" "index.js"
+             "Runtime" "nodejs6.10"
+             "CodeUri" "s3://my-code-bucket/my-function.zip"
+             "MemorySize" 1024
+             "Timeout" 15
+             "Policies" ["AWSLambdaExecute"
+                         {"Version" "2012-10-17"
+                          "Statement" [{"Effect" "Allow"
+                                        "Action" ["s3:GetObject"
+                                                  "s3:GetObjectACL"]
+                                        "Resource" "arn:aws:s3:::my-bucket/*"}]}]
+             "Environment" {"Variables" {"TableName" "my-table"}}
+             "Events" {"PhotoUpload" {"Type" "S3"
+                                      "Properties" {"Bucket" "my-photo-bucket"}}}
+             "Tags" {"AppNameTag" "ThumbnailApp"
+                     "DepartmentNameTag" "ThumbnailDepartment"}
+             "Layers" "arn:aws:lambda:${AWS:Region}:123456789012:layer:MyLayer:1"}}
+           (crucible.encoding/rewrite-element-data
+            (f/function
+             {::f/handler "index.js"
+              ::f/runtime "nodejs6.10"
+              ::f/code-uri "s3://my-code-bucket/my-function.zip"
+              ::f/memory-size 1024
+              ::f/timeout 15
+              ::f/policies ["AWSLambdaExecute"
+                            {::iam/version "2012-10-17"
+                             ::iam/statement [{::iam/effect "Allow"
+                                                ::iam/action ["s3:GetObject"
+                                                              "s3:GetObjectACL"]
+                                                ::iam/resource "arn:aws:s3:::my-bucket/*"}]}]
+              ::f/environment {::f/variables {:TABLE_NAME "my-table"}}
+              ::f/events {:photo-upload {::es/type "S3"
+                                         ::properties {::bucket "my-photo-bucket"}}}
+              ::f/tags {:app-name-tag "ThumbnailApp"
+                        :department-name-tag "ThumbnailDepartment"}
+              ::f/layers "arn:aws:lambda:${AWS:Region}:123456789012:layer:MyLayer:1"}))))))

--- a/test/crucible/aws/serverless/layer_version_test.clj
+++ b/test/crucible/aws/serverless/layer_version_test.clj
@@ -1,0 +1,28 @@
+(ns crucible.aws.serverless.layer-version-test
+  (:require [crucible.aws.serverless :as sam]
+            [crucible.aws.serverless.layer-version :as lv]
+            [crucible.core :refer [xref]]
+            [crucible.resources :as res]
+            [clojure.test :refer :all]
+            [crucible.encoding :as encoding]))
+
+(deftest layer-version-test
+  (testing "encoding"
+    (is (= {"Type" "AWS::Serverless::LayerVersion"
+            "Properties"
+            {"LayerName" "MyLayer"
+             "Description" "Layer description"
+             "ContentUri" "s3://my-bucket/my-layer.zip"
+             "CompatibleRuntimes" ["nodejs6.10"
+                                   "nodejs8.10"]
+             "LicenseInfo" "Available under the MIT-0 license."
+             "RetentionPolicy" "Retain"}}
+           (encoding/rewrite-element-data
+            (lv/layer-version
+             {::lv/layer-name "MyLayer"
+              ::lv/description "Layer description"
+              ::lv/content-uri "s3://my-bucket/my-layer.zip"
+              ::lv/compatible-runtimes ["nodejs6.10"
+                                        "nodejs8.10"]
+              ::lv/license-info "Available under the MIT-0 license."
+              ::lv/retention-policy "Retain"}))))))

--- a/test/crucible/aws/serverless/simple_table_test.clj
+++ b/test/crucible/aws/serverless/simple_table_test.clj
@@ -1,0 +1,31 @@
+(ns crucible.aws.serverless.simple-table-test
+  (:require [crucible.aws.dynamodb :as ddb]
+            [crucible.aws.serverless :as sam]
+            [crucible.aws.serverless.simple-table :as st]
+            [crucible.core :refer [xref]]
+            [crucible.resources :as res]
+            [clojure.test :refer :all]
+            [crucible.encoding :as encoding]))
+
+(deftest simple-table-test
+  (testing "encode"
+    (is (= {"Type" "AWS::Serverless::SimpleTable"
+            "Properties"
+            {"TableName" "my-table"
+             "PrimaryKey" {"Name" "id"
+                           "Type" "String"}
+             "ProvisionedThroughput" {"ReadCapacityUnits" 5
+                                      "WriteCapacityUnits" 5}
+             "Tags" {"Department" "Engineering"
+                     "AppType" "Serverless"}
+             "SseSpecification" {"SseEnabled" true}}}
+           (encoding/rewrite-element-data
+            (st/simple-table
+             {::st/table-name "my-table"
+              ::st/primary-key {::sam/name "id"
+                                ::sam/type "String"}
+              ::st/provisioned-throughput {::ddb/read-capacity-units 5
+                                           ::ddb/write-capacity-units 5}
+              ::st/tags {:department "Engineering"
+                         :app-type "Serverless"}
+              ::st/sse-specification {::ddb/sse-enabled true}}))))))

--- a/test/crucible/encoding/serverless_test.clj
+++ b/test/crucible/encoding/serverless_test.clj
@@ -1,0 +1,79 @@
+(ns crucible.encoding.serverless-test
+  (:require [crucible.aws.kinesis :as k]
+            [crucible.aws.serverless.function :as f]
+            [crucible.aws.serverless.function.event-source :as es]
+            [crucible.aws.serverless.function.event-source.kinesis :as es.k]
+            [crucible.aws.serverless.globals :as g]
+            [crucible.core :refer [xref template]]
+            [crucible.encoding.serverless :as encoding.sam]
+            [clojure.test :refer :all]))
+
+(deftest serverless-test
+  (testing "encode without globals"
+    (is (= {"AWSTemplateFormatVersion" "2010-09-09"
+            "Transform" "AWS::Serverless-2016-10-31"
+            "Description" "A function that processes data from a Kinesis stream."
+            "Resources" {"StreamProcessor"
+                         {"Type" "AWS::Serverless::Function"
+                          "Properties"
+                          {"Handler" "index.handler"
+                           "Runtime" "nodejs6.10"
+                           "CodeUri" "src/"
+                           "Events" {"Stream" {"Type" "Kinesis"
+                                               "Properties" {"Stream" {"Fn::GetAtt" ["Stream" "Arn"]}
+                                                             "StartingPosition" "TRIM_HORIZON"}}}}}
+
+                         "Stream"
+                         {"Type" "AWS::Kinesis::Stream"
+                          "Properties" {"ShardCount" 1}}}}
+           (encoding.sam/build
+            (template {:stream-processor
+                       (f/function
+                        {::f/handler "index.handler"
+                         ::f/runtime "nodejs6.10"
+                         ::f/code-uri "src/"
+                         ::f/events {:stream
+                                     {::es/type "Kinesis"
+                                      ::es.k/properties
+                                      {::es.k/stream (xref :stream :arn)
+                                       ::es.k/starting-position "TRIM_HORIZON"}}}})
+                       :stream (k/stream
+                                {::k/shard-count 1})}
+                      "A function that processes data from a Kinesis stream.")))))
+
+  (testing "encode with globals"
+    (is (= {"AWSTemplateFormatVersion" "2010-09-09"
+            "Transform" "AWS::Serverless-2016-10-31"
+            "Description" "A function that processes data from a Kinesis stream."
+            "Globals" {"Function" {"MemorySize" 1024
+                                   "Timeout" 15}}
+            "Resources" {"StreamProcessor"
+                         {"Type" "AWS::Serverless::Function"
+                          "Properties"
+                          {"Handler" "index.handler"
+                           "Runtime" "nodejs6.10"
+                           "CodeUri" "src/"
+                           "Events" {"Stream" {"Type" "Kinesis"
+                                               "Properties" {"Stream" {"Fn::GetAtt" ["Stream" "Arn"]}
+                                                             "StartingPosition" "TRIM_HORIZON"}}}}}
+
+                         "Stream"
+                         {"Type" "AWS::Kinesis::Stream"
+                          "Properties" {"ShardCount" 1}}}}
+           (encoding.sam/build
+            (template {:stream-processor
+                       (f/function
+                        {::f/handler "index.handler"
+                         ::f/runtime "nodejs6.10"
+                         ::f/code-uri "src/"
+                         ::f/events {:stream
+                                     {::es/type "Kinesis"
+                                      ::es.k/properties
+                                      {::es.k/stream (xref :stream :arn)
+                                       ::es.k/starting-position "TRIM_HORIZON"}}}})
+                       :stream (k/stream
+                                {::k/shard-count 1})}
+                      "A function that processes data from a Kinesis stream.")
+            (g/globals
+             {::g/function {::f/memory-size 1024
+                            ::f/timeout 15}}))))))


### PR DESCRIPTION
Adds support for AWS Serverless Application Model (SAM) templates with a couple of updates to existing resources where applicable. 

AWS SAM https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md

I tried to organize the code in the same way as AWS organized the SAM resource hierarchy. That means general data-types go into the `crucible.aws.serverless` namespace. All actual resources go into `crucible.aws.serverless.<resource>` namespaces with some additional sub-directories when necessary. There is a new `crucible.encoding.serverless` namespace that handles global values as well as injecting the correct transformation into the converted template. `crucible.core/template` works just fine for SAM resources. SAM resources and CF resources can be used in the same template with no issue.

This is a pretty big PR and I am happy to help explain anything that isn't clear. @AdamFrey isn't listed as a contributor but deserves a big shout out for working on many of the specs.