### PR TITLE
The value of a tag should support a spec-or-ref

### DIFF
--- a/src/crucible/resources.clj
+++ b/src/crucible/resources.clj
@@ -20,8 +20,14 @@
 (s/def ::resource (s/keys :req [::type ::properties]
                           :opt [::policies/policies]))
 
+(defmacro spec-or-ref
+  "Allows the given spec, keyed as :literal, or a referenced value, keyed as :reference."
+  [spec]
+  `(s/or :literal ~spec
+         :reference :crucible.values/value))
+
 (s/def ::key string?)
-(s/def ::value string?)
+(s/def ::value (spec-or-ref string?))
 (s/def ::tag (s/keys :req [::key ::value]))
 (s/def ::tags (s/* ::tag))
 
@@ -46,12 +52,6 @@
          :else (-> {::type resource-type
                     ::properties props}
                    (merge (into {} (s/conform ::policy-list policies)))))])))
-
-(defmacro spec-or-ref
-  "Allows the given spec, keyed as :literal, or a referenced value, keyed as :reference."
-  [spec]
-  `(s/or :literal ~spec
-         :reference :crucible.values/value))
 
 (defmacro defresource
   "Adds a resource factory function to the namespace, documenting the AWS type"

--- a/test/crucible/examples_test.clj
+++ b/test/crucible/examples_test.clj
@@ -60,4 +60,3 @@
               "DeletionPolicy" "Retain"
               "DependsOn" "MyVpcCidr"}}}
          (json/decode (encode more-complex))))))
-

--- a/test/crucible/examples_test.clj
+++ b/test/crucible/examples_test.clj
@@ -1,9 +1,10 @@
 (ns crucible.examples-test
   (:require  [clojure.test :refer :all]
              [crucible
-              [core :refer [template parameter resource output xref encode join]]
+              [core :refer [template parameter resource output xref encode join stack-name]]
               [policies :as pol]
               [parameters :as param]]
+             [crucible.resources :as res]
              [crucible.aws.ec2 :as ec2]
              [cheshire.core :as json]))
 
@@ -27,7 +28,13 @@
                             :my-vpc-cidr (parameter ::param/type ::param/string
                                                     ::param/allowed-values ["10.0.0.0/24"
                                                                             "10.0.0.0/16"])
-                            :my-vpc (ec2/vpc {::ec2/cidr-block (xref :my-vpc-cidr)}
+                            :my-vpc (ec2/vpc {::ec2/cidr-block (xref :my-vpc-cidr)
+                                              ::res/tags [{::res/key "Xref"
+                                                           ::res/value (xref :my-vpc-cidr)}
+                                                          {::res/key "String"
+                                                           ::res/value "Hello"}
+                                                          {::res/key "StackName"
+                                                           ::res/value stack-name}]}
                                              (pol/deletion ::pol/retain)
                                              (pol/depends-on :my-vpc-cidr))
                             :vpc (output (join "/" ["foo" (xref :my-vpc)]))))

--- a/test/crucible/examples_test.clj
+++ b/test/crucible/examples_test.clj
@@ -41,17 +41,23 @@
 
 (deftest example-more-complex
   (testing "Matches documented output"
-    (is (= {"AWSTemplateFormatVersion" "2010-09-09",
-            "Description" "A more complex sample template",
+    (is (= {"AWSTemplateFormatVersion" "2010-09-09"
+            "Description" "A more complex sample template"
             "Outputs"
-            {"Vpc" {"Value" {"Fn::Join" ["/" ["foo" {"Ref" "MyVpc"}]]}}},
+            {"Vpc" {"Value" {"Fn::Join" ["/" ["foo" {"Ref" "MyVpc"}]]}}}
             "Parameters"
             {"MyVpcCidr"
-             {"Type" "String", "AllowedValues" ["10.0.0.0/24" "10.0.0.0/16"]}},
+             {"Type" "String", "AllowedValues" ["10.0.0.0/24" "10.0.0.0/16"]}}
             "Resources"
             {"MyVpc"
-             {"Type" "AWS::EC2::VPC",
-              "Properties" {"CidrBlock" {"Ref" "MyVpcCidr"}},
-              "DeletionPolicy" "Retain",
+             {"Type" "AWS::EC2::VPC"
+              "Properties"
+              {"CidrBlock" {"Ref" "MyVpcCidr"}
+               "Tags"
+               [{"Key" "Xref", "Value" {"Ref" "MyVpcCidr"}}
+                {"Key" "String", "Value" "Hello"}
+                {"Key" "StackName", "Value" {"Ref" "AWS::StackName"}}]}
+              "DeletionPolicy" "Retain"
               "DependsOn" "MyVpcCidr"}}}
-           (json/decode (encode more-complex))))))
+         (json/decode (encode more-complex))))))
+


### PR DESCRIPTION
It’s useful to be able to reference an xref in the value of tags. Specific use case would be using tags with billing and setting an stage or stack name. This give the ::value spec the ability to take in a ref.