### PR TITLE
Add missing spec for availability-zone in auto scaling groups

### DIFF
--- a/src/crucible/aws/auto_scaling/auto_scaling_group.clj
+++ b/src/crucible/aws/auto_scaling/auto_scaling_group.clj
@@ -21,6 +21,7 @@
 
 (s/def ::min-size (spec-or-ref string?))
 (s/def ::max-size (spec-or-ref string?))
+(s/def ::availability-zone (spec-or-ref string?))
 (s/def ::availability-zones (s/* ::availability-zone))
 (s/def ::cool-down (spec-or-ref string?))
 (s/def ::desired-capacity (spec-or-ref string?))

--- a/test/crucible/aws/auto_scaling/auto_scaling_group_test.clj
+++ b/test/crucible/aws/auto_scaling/auto_scaling_group_test.clj
@@ -7,7 +7,8 @@
   (testing "valid auto scaling group"
     (is (s/valid? ::sut/resource-spec
                   {::sut/min-size "2"
-                   ::sut/max-size "2"})))
+                   ::sut/max-size "2"
+                   ::sut/availability-zones ["us-east-1"]})))
   (testing "invalid auto scaling group"
     (is (not (s/valid? ::sut/resource-spec
                        {})))))


### PR DESCRIPTION
Spec ::availability-zone was used in the ::availability-zones spec but not defined in the crucible.aws.auto-scaling.auto-scaling-group namespace. This PR adds that missing spec. 