### PR TITLE
Add metadata section

### DIFF
--- a/src/crucible/policies.clj
+++ b/src/crucible/policies.clj
@@ -44,7 +44,7 @@
 
 (s/def ::depends-on keyword?)
 
-(s/def ::policy (s/or 
+(s/def ::policy (s/or
                  :deletion-policy ::deletion-policy
                  :depends-on ::depends-on
                  :creation-policy ::creation-policy

--- a/src/crucible/policies.clj
+++ b/src/crucible/policies.clj
@@ -10,8 +10,11 @@
 (s/def ::resource-signal (s/keys :opt [::count
                                        ::timeout]))
 
-(s/def ::creation-policy (s/keys :opt [::auto-scaling-creation-policy
-                                       ::resource-signal]))
+(s/def ::creation-policy (s/keys :req
+                                 [(or ::auto-scaling-creation-policy
+                                      ::resource-signal)]))
+
+(s/def ::metadata (s/keys))
 
 (s/def ::will-replace boolean?)
 (s/def ::auto-scaling-replacing-update (s/keys :opt [::will-replace]))
@@ -32,22 +35,27 @@
 (s/def ::ignore-unmodified-groups-size-properties boolean?)
 (s/def ::auto-scaling-scheduled-action (s/keys :opt [::ignore-unmodified-groups-size-properties]))
 
-(s/def ::update-policy (s/keys :opt [::auto-scaling-replacing-update
-                                     ::auto-scaling-rolling-update
-                                     ::auto-scaling-scheduled-action]))
+(s/def ::update-policy (s/keys :req
+                               [(or ::auto-scaling-replacing-update
+                                    ::auto-scaling-rolling-update
+                                    ::auto-scaling-scheduled-action)]))
 
 (s/def ::deletion-policy #{::retain ::delete ::snapshot})
 
 (s/def ::depends-on keyword?)
 
-(s/def ::policy (s/or :deletion-policy ::deletion-policy
-                      :depends-on ::depends-on
-                      :creation-policy ::creation-policy
-                      :update-policy ::update-policy))
+(s/def ::policy (s/or 
+                 :deletion-policy ::deletion-policy
+                 :depends-on ::depends-on
+                 :creation-policy ::creation-policy
+                 :update-policy ::update-policy
+                 :metadata ::metadata))
 
 (s/def ::policies (s/keys :opt [::deletion-policy
                                 ::depends-on
-                                ::creation-policy]))
+                                ::creation-policy
+                                ::update-policy
+                                ::metadata]))
 
 
 (defn deletion [policy]
@@ -60,4 +68,7 @@
   policy)
 
 (defn update-policy [policy]
+  policy)
+
+(defn metadata [policy]
   policy)

--- a/test/crucible/encoding/template_test.clj
+++ b/test/crucible/encoding/template_test.clj
@@ -42,7 +42,7 @@
             (encode
              (template "t"
                        :my-vpc (ec2/vpc {::ec2/cidr-block "10.0.0.0/16"}
-                                        (pol/metadata {"Instances" 
+                                        (pol/metadata {"Instances"
                                                        {"Description" "Info about vpc"}})))))))))
 
 (deftest template-resource-with-creation-policies-test

--- a/test/crucible/encoding/template_test.clj
+++ b/test/crucible/encoding/template_test.clj
@@ -30,6 +30,21 @@
                        :my-vpc (ec2/vpc {::ec2/cidr-block "10.0.0.0/16"}
                                         (pol/deletion ::pol/retain)))))))))
 
+
+(deftest template-resource-with-metadata-test
+  (testing "template with resource with metadata policy"
+    (is (= {"AWSTemplateFormatVersion" "2010-09-09"
+            "Description" "t"
+            "Resources" {"MyVpc" {"Type" "AWS::EC2::VPC"
+                                  "Properties" {"CidrBlock" "10.0.0.0/16"}
+                                  "Metadata" {"Instances" {"Description" "Info about vpc"}}}}}
+           (cheshire.core/decode
+            (encode
+             (template "t"
+                       :my-vpc (ec2/vpc {::ec2/cidr-block "10.0.0.0/16"}
+                                        (pol/metadata {"Instances" 
+                                                       {"Description" "Info about vpc"}})))))))))
+
 (deftest template-resource-with-creation-policies-test
   (testing "template with resource with deletion policy"
     (is (= {"AWSTemplateFormatVersion" "2010-09-09"

--- a/test/crucible/encoding/template_test.clj
+++ b/test/crucible/encoding/template_test.clj
@@ -52,12 +52,12 @@
                                    ::pol/timeout "PT10M"}})))))))))
 
 (deftest template-resource-with-update-policies-test
-  (testing "template with resource with deletion policy"
+  (testing "template with resource with update policy"
     (is (= {"AWSTemplateFormatVersion" "2010-09-09"
             "Description" "t"
             "Resources" {"MyAsg" {"Type" "AWS::AutoScaling::AutoScalingGroup"
                                   "Properties" {"MaxSize" "0" "MinSize" "1"}
-                                  "CreationPolicy" {"AutoScalingRollingUpdate"
+                                  "UpdatePolicy" {"AutoScalingRollingUpdate"
                                                     {"MaxBatchSize" 1
                                                      "MinInstanceInService" 0
                                                      "PauseTime" "PT10M"


### PR DESCRIPTION
Add support for adding a metadata section to resources. 
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/metadata-section-structure.html

It's not really a policy but because of the way it's defined in the structure of a CloudFormation template it seems like this is the best place to define it. The metadata section can be any arbitrary json so the spec for it has to be loose. Depending on the resource it could be one of these metadata keys. For those, we can define a proper spec for them. For now I'll leave that for another pull request. 