### PR TITLE
Adds special tags for autoscaling groups

### DIFF
--- a/src/crucible/aws/auto_scaling/auto_scaling_group.clj
+++ b/src/crucible/aws/auto_scaling/auto_scaling_group.clj
@@ -54,6 +54,15 @@
 (s/def ::vpc-zone-id (spec-or-ref string?))
 (s/def ::v-p-c-zone-identifier (s/* ::vpc-zone-id))
 
+(s/def ::key string?)
+(s/def ::resource-type string?)
+(s/def ::resource-id string?)
+(s/def ::propagate-at-launch boolean?)
+(s/def ::value (spec-or-ref string?))
+(s/def ::tag (s/keys :req [::key ::value]
+                     :opt [::resource-id ::resource-type ::propagate-at-launch]))
+(s/def ::tags (s/* ::tag))
+
 (s/def ::resource-spec (s/keys :req [::max-size
                                           ::min-size]
                                     :opt [::availability-zones
@@ -72,4 +81,5 @@
                                           ::target-group-arns
                                           ::termination-policies
                                           ::v-p-c-zone-identifier
+                                          ::tags
                                           ::res/tags]))

--- a/test/crucible/aws/auto_scaling/auto_scaling_group_test.clj
+++ b/test/crucible/aws/auto_scaling/auto_scaling_group_test.clj
@@ -8,7 +8,12 @@
     (is (s/valid? ::sut/resource-spec
                   {::sut/min-size "2"
                    ::sut/max-size "2"
-                   ::sut/availability-zones ["us-east-1"]})))
+                   ::sut/availability-zones ["us-east-1"]
+                   ::sut/tags [{::sut/key "Name"
+                                ::sut/value "Testing"
+                                ::sut/propagate-at-launch true
+                                ::sut/resource-type "auto-scaling-group"
+                                ::sut/resource-id "my-asg"}]})))
   (testing "invalid auto scaling group"
     (is (not (s/valid? ::sut/resource-spec
                        {})))))


### PR DESCRIPTION
Auto Scaling groups have special tags that are specific to autoscaling groups. This commit adds a ASG specific spec for those tags. https://docs.aws.amazon.com/autoscaling/ec2/userguide/autoscaling-tagging.html