### PR TITLE
Adds key override for cool-down key

### DIFF
--- a/src/crucible/aws/auto_scaling/auto_scaling_group.clj
+++ b/src/crucible/aws/auto_scaling/auto_scaling_group.clj
@@ -1,7 +1,10 @@
 (ns crucible.aws.auto-scaling.auto-scaling-group
   "AWS::AutoScaling::AutoScalingGroup"
   (:require [clojure.spec.alpha :as s]
-            [crucible.resources :refer [spec-or-ref] :as res]))
+            [crucible.resources :refer [spec-or-ref] :as res]
+            [crucible.encoding.keys :refer [->key]]))
+
+(defmethod ->key :cool-down [_] "Cooldown")
 
 (s/def ::default-result (spec-or-ref string?))
 (s/def ::heartbeat-timeout (spec-or-ref string?))


### PR DESCRIPTION
The resulting json key from cool-down spec is Cooldown and not CoolDown. I added an override to stay compatible with the current keys. However, we could just correct the spec key to be ::cooldown. https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-cooldown