### PR TITLE
Condition policy

### DIFF
--- a/src/crucible/aws/auto_scaling/auto_scaling_group.clj
+++ b/src/crucible/aws/auto_scaling/auto_scaling_group.clj
@@ -1,7 +1,10 @@
 (ns crucible.aws.auto-scaling.auto-scaling-group
   "AWS::AutoScaling::AutoScalingGroup"
   (:require [clojure.spec.alpha :as s]
-            [crucible.resources :refer [spec-or-ref] :as res]))
+            [crucible.resources :refer [spec-or-ref] :as res]
+            [crucible.encoding.keys :refer [->key]]))
+
+(defmethod ->key :cool-down [_] "Cooldown")
 
 (s/def ::default-result (spec-or-ref string?))
 (s/def ::heartbeat-timeout (spec-or-ref string?))

--- a/src/crucible/policies.clj
+++ b/src/crucible/policies.clj
@@ -44,31 +44,38 @@
 
 (s/def ::depends-on keyword?)
 
+(s/def ::condition keyword?)
+
 (s/def ::policy (s/or
                  :deletion-policy ::deletion-policy
                  :depends-on ::depends-on
                  :creation-policy ::creation-policy
                  :update-policy ::update-policy
-                 :metadata ::metadata))
+                 :metadata ::metadata
+                 :condition ::condition))
 
 (s/def ::policies (s/keys :opt [::deletion-policy
                                 ::depends-on
                                 ::creation-policy
                                 ::update-policy
-                                ::metadata]))
+                                ::metadata
+                                ::condition]))
 
 
 (defn deletion [policy]
-  policy)
+  {::deletion-policy policy})
 
 (defn depends-on [kw]
-  kw)
+  {::depends-on kw})
 
 (defn creation-policy [policy]
-  policy)
+  {::creation-policy policy})
 
 (defn update-policy [policy]
-  policy)
+  {::update-policy policy})
 
 (defn metadata [policy]
-  policy)
+  {::metadata policy})
+
+(defn condition [kw]
+  {::condition kw})

--- a/src/crucible/resources.clj
+++ b/src/crucible/resources.clj
@@ -37,7 +37,7 @@
 
 (def invalid? (complement s/valid?))
 
-(s/def ::policy-list (s/* ::policies/policy))
+(s/def ::policy-list (s/* ::policies/policies))
 
 (defn resource-factory [resource-type props-spec]
   (if-not (s/valid? ::type resource-type)

--- a/test/crucible/encoding/template_test.clj
+++ b/test/crucible/encoding/template_test.clj
@@ -135,11 +135,17 @@
   (testing "template with single condition"
     (is (= {"AWSTemplateFormatVersion" "2010-09-09"
             "Description" "t"
-            "Conditions" {"Production" {"Fn::Equals" [{"Ref" "AWS::StackName"} "production"]}}}
+            "Conditions" {"Production" {"Fn::Equals" [{"Ref" "AWS::StackName"} "production"]}}
+            "Resources" {"MyVpc" {"Type" "AWS::EC2::VPC" "Properties" {"CidrBlock" "0.0.0.0/0"}
+                                  "Condition" "Production"}}}
            (cheshire.core/decode
             (encode
              (template "t"
-                       :production (condition (equals stack-name "production"))))))))
+                       :production (condition (equals stack-name "production"))
+                       :my-vpc (ec2/vpc
+                                {::ec2/cidr-block "0.0.0.0/0"}
+                                (pol/condition :production))
+                       ))))))
 
   (testing "template with multiple conditions"
     (is (= {"AWSTemplateFormatVersion" "2010-09-09"


### PR DESCRIPTION
This adds a conditions section policy that can be used to conditionally create a resource in Cloudformation. 
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/conditions-section-structure.html

It also refactors the ::resource spec to use the ::policies spec instead of the ::plolicy spec. This is to allow policies with similar data structure to work together. 

