### PR TITLE
Add iam instance profile

### DIFF
--- a/src/crucible/aws/auto_scaling/auto_scaling_group.clj
+++ b/src/crucible/aws/auto_scaling/auto_scaling_group.clj
@@ -45,10 +45,10 @@
 (s/def ::load-balancer-names (s/* ::load-balancer-name))
 (s/def ::metric-collection (s/keys :req [::granularity]
                                    :opt [::metrics]))
-(s/def ::metric-collections (s/* ::metric-collection))
+(s/def ::metrics-collection (s/* ::metric-collection))
 (s/def ::notification-configuration (s/keys :req [::notification-types
                                                   ::topic-arn]))
-(s/def ::notification-configurations (s/* ::metric-collection))
+(s/def ::notification-configurations (s/* ::metrics-collection))
 (s/def ::placement-group (spec-or-ref string?))
 (s/def ::target-group-arn (spec-or-ref string?))
 (s/def ::target-group-arns (s/* ::target-group-arn))

--- a/src/crucible/aws/iam.clj
+++ b/src/crucible/aws/iam.clj
@@ -134,3 +134,10 @@
                                                                  "logs:PutLogEvents"]
                                                        ::effect "Allow"
                                                        ::resource "*"})}}]}))
+
+(s/def ::instance-profile-name (spec-or-ref string?))
+
+(s/def ::instance-profile (s/keys :req [::roles]
+                                  :opt [::path]))
+
+(defresource instance-profile "AWS::IAM::InstanceProfile" ::instance-profile)

--- a/test/crucible/encoding/template_test.clj
+++ b/test/crucible/encoding/template_test.clj
@@ -262,7 +262,7 @@
   (testing "template with instance profile"
     (is (= {"AWSTemplateFormatVersion" "2010-09-09"
             "Description" "t"
-            "Resources" 
+            "Resources"
             {"InstanceProfile"
              {"Type" "AWS::IAM::InstanceProfile",
               "Properties" {"Path" "/",


### PR DESCRIPTION
Adds resource spec for AWS::IAM::InstanceProfile. https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-instanceprofile.html