### PR TITLE
Fix ASG rolling-update/creation policy prop names

### DIFF
--- a/src/crucible/policies.clj
+++ b/src/crucible/policies.clj
@@ -2,8 +2,8 @@
   (:require [clojure.spec.alpha :as s]
             [crucible.encoding.keys :refer [->key]]))
 
-(s/def ::min-successful-instance-percent int?)
-(s/def ::auto-scaling-creation-policy (s/keys :opt [::min-successful-instance-percent]))
+(s/def ::min-successful-instances-percent int?)
+(s/def ::auto-scaling-creation-policy (s/keys :opt [::min-successful-instances-percent]))
 
 (s/def ::count int?)
 (s/def ::timeout string?)
@@ -20,14 +20,14 @@
 (s/def ::auto-scaling-replacing-update (s/keys :opt [::will-replace]))
 
 (s/def ::max-batch-size int?)
-(s/def ::min-instance-in-service int?)
+(s/def ::min-instances-in-service int?)
 (s/def ::pause-time string?)
 (s/def ::suspend-processes (s/* string?))
 (s/def ::wait-on-resource-signals boolean?)
 
 (s/def ::auto-scaling-rolling-update (s/keys :opt [::max-batch-size
-                                                   ::min-instance-in-service
-                                                   ::min-successful-instance-percent
+                                                   ::min-instances-in-service
+                                                   ::min-successful-instances-percent
                                                    ::pause-time
                                                    ::suspend-processes
                                                    ::wait-on-resource-signals]))

--- a/test/crucible/encoding/template_test.clj
+++ b/test/crucible/encoding/template_test.clj
@@ -75,7 +75,7 @@
                                   "Properties" {"MaxSize" "0" "MinSize" "1"}
                                   "UpdatePolicy" {"AutoScalingRollingUpdate"
                                                     {"MaxBatchSize" 1
-                                                     "MinInstanceInService" 0
+                                                     "MinInstancesInService" 0
                                                      "PauseTime" "PT10M"
                                                      "WaitOnResourceSignals" true}}}}}
            (cheshire.core/decode
@@ -87,7 +87,7 @@
                                 (pol/update-policy
                                  {::pol/auto-scaling-rolling-update
                                   {::pol/max-batch-size 1
-                                   ::pol/min-instance-in-service 0
+                                   ::pol/min-instances-in-service 0
                                    ::pol/pause-time "PT10M"
                                    ::pol/wait-on-resource-signals true}})))))))))
 


### PR DESCRIPTION
AWS documentation on these property names can be found here:

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatepolicy.html

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-creationpolicy.html