### PR TITLE
Allow references in two Neptune DBCluster fields

### DIFF
--- a/src/crucible/aws/neptune/db_cluster.clj
+++ b/src/crucible/aws/neptune/db_cluster.clj
@@ -30,7 +30,8 @@
 
 (s/def ::storage-encrypted (spec-or-ref boolean?))
 
-(s/def ::vpc-security-group-ids (spec-or-ref (s/* string?)))
+(s/def ::vpc-security-group-ids (spec-or-ref (s/coll-of (spec-or-ref string?)
+                                                        :kind vector?)))
 
 (s/def ::db-cluster
   (s/keys :opt [::availability-zones

--- a/src/crucible/aws/neptune/db_cluster.clj
+++ b/src/crucible/aws/neptune/db_cluster.clj
@@ -5,7 +5,8 @@
             [crucible.encoding.keys :refer [->key]]
             [crucible.resources :refer [spec-or-ref defresource]]))
 
-(s/def ::availability-zones (spec-or-ref (s/* string?)))
+(s/def ::availability-zones (spec-or-ref (s/coll-of (spec-or-ref string?)
+                                                    :kind vector?)))
 
 (s/def ::backup-retention-period (spec-or-ref pos-int?))
 


### PR DESCRIPTION
The following can now be a mixed vector of strings and references:
* availability-zones
* vcp-security-group-ids