### PR TITLE
fix mount-point declaration

### DIFF
--- a/src/crucible/aws/ecs/container_definition.clj
+++ b/src/crucible/aws/ecs/container_definition.clj
@@ -67,9 +67,11 @@
 (s/def ::source-volume (spec-or-ref string?))
 (s/def ::read-only (spec-or-ref boolean?))
 
-(s/def ::mount-points (s/keys :req [::container-path
+(s/def ::mount-point (s/keys :req [::container-path
                                     ::source-volume]
                               :opt [::read-only]))
+
+(s/def ::mount-points (s/coll-of ::mount-point))
 
 (s/def ::container-port (spec-or-ref integer?))
 (s/def ::host-port (spec-or-ref integer?))


### PR DESCRIPTION
Currently using mount-point fails the spec, since the ECS expects a list of mount points as defined here:
https://docs.aws.amazon.com/AmazonECS/latest/developerguide/bind-mounts.html
This fix changes updates the spec to reflect how it should be.